### PR TITLE
Fix missing genre name in show creation

### DIFF
--- a/MediaVault.Services/Services/ShowService.cs
+++ b/MediaVault.Services/Services/ShowService.cs
@@ -76,13 +76,15 @@ public class ShowService : IShowService
         };
 
         _repository.Add(show);
+        // Reload the show with its related Genre to populate the response
+        var savedShow = _repository.GetById(show.Id);
 
         var result = new ShowDto
         {
             Id = show.Id,
             Title = show.Title,
             GenreId = show.GenreId,
-            GenreName = show.Genre?.Name ?? "",
+            GenreName = savedShow?.Genre.Name ?? string.Empty,
             Seasons = show.Seasons,
             Type = show.Type,
             IsCompleted = show.IsCompleted,


### PR DESCRIPTION
## Summary
- reload show entity after saving to populate genre name for API response

## Testing
- `dotnet test` (no tests found)
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a37a487e0832483ac9afd4485e5e6