### PR TITLE
Add shows-by-genre endpoint with Dapper query

### DIFF
--- a/MediaVault.API/Controllers/GenresController.cs
+++ b/MediaVault.API/Controllers/GenresController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using MediaVault.Models;
 using MediaVault.Models.DTOs.Genres;
+using MediaVault.Models.DTOs.Shows;
 using MediaVault.Services.Interfaces;
 
 namespace MediaVault.Controllers
@@ -25,6 +26,26 @@ namespace MediaVault.Controllers
                 Status = "success",
                 Message = "All genres retrieved.",
                 Data = genres
+            });
+        }
+
+        [HttpGet("{id}/shows")]
+        public async Task<ActionResult<ApiResponse<IEnumerable<ShowDto>>>> GetShowsByGenre(int id)
+        {
+            var shows = await _genreService.GetShowsByGenreIdAsync(id);
+            if (shows == null)
+                return NotFound(new ApiResponse<IEnumerable<ShowDto>>
+                {
+                    Status = "fail",
+                    Message = $"No genre found with ID = {id}",
+                    Error = "Genre not found"
+                });
+
+            return Ok(new ApiResponse<IEnumerable<ShowDto>>
+            {
+                Status = "success",
+                Message = "Shows for genre retrieved.",
+                Data = shows
             });
         }
 

--- a/MediaVault.Repositories/MediaVault.Repositories.csproj
+++ b/MediaVault.Repositories/MediaVault.Repositories.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Dapper" Version="2.1.66" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MediaVault.Repositories/Repositories/GenreRepository.cs
+++ b/MediaVault.Repositories/Repositories/GenreRepository.cs
@@ -1,6 +1,11 @@
-﻿using MediaVault.Repositories.Data;
+﻿using Dapper;
+using MediaVault.Repositories.Data;
 using MediaVault.Models.Entities;
 using MediaVault.Repositories.Interfaces;
+using MediaVault.Models.DTOs.Shows;
+using System.Data;
+using System;
+using Microsoft.EntityFrameworkCore;
 
 namespace MediaVault.Repositories
 {
@@ -50,6 +55,23 @@ namespace MediaVault.Repositories
         public bool Exists(int id)
         {
             return _context.Genres.Any(g => g.Id == id);
+        }
+
+        public async Task<IEnumerable<ShowDto>> GetShowsByGenreIdAsync(int genreId)
+        {
+            var sql = @"SELECT s.Id, s.Title, s.GenreId, g.Name AS GenreName, s.Seasons, s.Type,
+                               s.IsCompleted, s.Language, s.Country, s.Summary, s.ReleaseDate, s.Rating
+                        FROM Shows s
+                        INNER JOIN Genres g ON s.GenreId = g.Id
+                        WHERE s.GenreId = @GenreId AND s.IsDeleted = 0 AND g.IsDeleted = 0
+                        ORDER BY s.Rating DESC";
+
+            using var connection = _context.Database.GetDbConnection();
+            if (connection.State != ConnectionState.Open)
+                await connection.OpenAsync();
+
+            var shows = await connection.QueryAsync<ShowDto>(sql, new { GenreId = genreId });
+            return shows ?? Array.Empty<ShowDto>();
         }
     }
 }

--- a/MediaVault.Repositories/Repositories/Interfaces/IGenreRepository.cs
+++ b/MediaVault.Repositories/Repositories/Interfaces/IGenreRepository.cs
@@ -1,4 +1,5 @@
 ﻿using MediaVault.Models.Entities;
+using MediaVault.Models.DTOs.Shows;
 
 namespace MediaVault.Repositories.Interfaces
 {
@@ -10,5 +11,6 @@ namespace MediaVault.Repositories.Interfaces
         void Update(Genre genre);
         void Delete(int id);
         bool Exists(int id);
+        Task<IEnumerable<ShowDto>> GetShowsByGenreIdAsync(int genreId);
     }
 }

--- a/MediaVault.Services/Services/GenreService.cs
+++ b/MediaVault.Services/Services/GenreService.cs
@@ -1,4 +1,5 @@
 ﻿using MediaVault.Models.DTOs.Genres;
+using MediaVault.Models.DTOs.Shows;
 using MediaVault.Models.Entities;
 using MediaVault.Repositories.Interfaces;
 using MediaVault.Services.Interfaces;
@@ -83,6 +84,14 @@ namespace MediaVault.Services
             genre.IsDeleted = true;
             _repository.Update(genre);
             return await Task.FromResult(true);
+        }
+
+        public async Task<IEnumerable<ShowDto>?> GetShowsByGenreIdAsync(int id)
+        {
+            if (!_repository.Exists(id)) return await Task.FromResult<IEnumerable<ShowDto>?>(null);
+
+            var shows = await _repository.GetShowsByGenreIdAsync(id);
+            return shows;
         }
     }
 }

--- a/MediaVault.Services/Services/Interfaces/IGenreService.cs
+++ b/MediaVault.Services/Services/Interfaces/IGenreService.cs
@@ -1,4 +1,5 @@
 ﻿using MediaVault.Models.DTOs.Genres;
+using MediaVault.Models.DTOs.Shows;
 
 namespace MediaVault.Services.Interfaces
 {
@@ -9,5 +10,6 @@ namespace MediaVault.Services.Interfaces
         Task<GenreDto> CreateAsync(CreateGenreDto dto);
         Task<bool> UpdateAsync(int id, UpdateGenreDto dto);
         Task<bool> DeleteAsync(int id);
+        Task<IEnumerable<ShowDto>?> GetShowsByGenreIdAsync(int id);
     }
 }


### PR DESCRIPTION
## Summary
- add Dapper query to GenreRepository to fetch shows by genre
- expose service and controller endpoint `GET /api/genres/{id}/shows`
- include Dapper package reference for repository project

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a4da6c77c8324811d6d7662bdf335